### PR TITLE
Configuración del entorno base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+#ignorar archivos generados
+
+commits.txt
+diffs.txt


### PR DESCRIPTION
Se actualizaron reglas en `.gitignore` para excluir archivos generados como `commits.txt` y `diffs.txt`.